### PR TITLE
Port audio update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,8 +163,8 @@ set(RT_INCLUDE_DIRS ${RTMIDI_SRC_DIR} ${RTAUDIO_SRC_DIR})
 
 # include portaudio
 if (USE_INTERNAL_PORTAUDIO)
-  add_subdirectory(submodules/PortAudio)
   set(PORTAUDIO_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/submodules/PortAudio/include)
+  add_subdirectory(src/portaudio)
   set(PORTAUDIO_LIBRARIES PortAudio)
 else()
   pkg_check_modules(PORTAUDIO REQUIRED portaudio-2.0)

--- a/src/portaudio/CMakeLists.txt
+++ b/src/portaudio/CMakeLists.txt
@@ -7,8 +7,8 @@ message(STATUS "PortAudio build Configuration")
 INCLUDE (CheckIncludeFile)
 INCLUDE (CheckCXXSourceCompiles)
 
-include_directories(include)
-include_directories(common)
+include_directories(${PORTAUDIO_INCLUDE_DIRS})
+include_directories(${CMAKE_SOURCE_DIR}/submodules/PortAudio/src/common)
 
 CHECK_INCLUDE_FILE (sys/soundcard.h HAVE_SYS_SOUNDCARD_H)
 if (HAVE_SYS_SOUNDCARD_H)


### PR DESCRIPTION
I've made necessary changes for switching to the new portaudio.

Unfornunally GO couldn't be compiled with PortAudio 19.7.0 for windows  so I made a fix to PortAudio https://github.com/PortAudio/portaudio/compare/147dd722548358763a8b649b3e4b41dfffbcfbb6...71d2d13f89ec40a86fd027aa390ff4d86280b8a0.

I've made a PR https://github.com/PortAudio/portaudio/pull/659 to PortAudio. Until merge of that PR GO may be compiled against the patched version of PortAudio.

After you merge this PR into your fork your PR https://github.com/GrandOrgue/grandorgue/pull/801 will be able to merge to GO.